### PR TITLE
Change gml file import

### DIFF
--- a/src/kiara_modules/network_analysis/network_data/__init__.py
+++ b/src/kiara_modules/network_analysis/network_data/__init__.py
@@ -422,7 +422,7 @@ class CreateNetworkDataModule(CreateValueModule):
 
         try:
             graph = nx.read_gml(input_file.path)
-        except KeyError as e:
+        except Exception as e:
             print(f"That didn't work: {e}")
             graph = nx.read_gml(input_file.path, label="id")
 

--- a/src/kiara_modules/network_analysis/network_data/__init__.py
+++ b/src/kiara_modules/network_analysis/network_data/__init__.py
@@ -420,7 +420,11 @@ class CreateNetworkDataModule(CreateValueModule):
 
         input_file: KiaraFile = value.get_value_data()
 
-        graph = nx.read_gml(input_file.path)
+        try:
+            graph = nx.read_gml(input_file.path)
+        except KeyError as e:
+            print(f"That didn't work: {e}")
+            graph = nx.read_gml(input_file.path, label="id")
 
         network_data = NetworkData.create_from_networkx_graph(graph)
         return network_data

--- a/src/kiara_modules/network_analysis/network_data/__init__.py
+++ b/src/kiara_modules/network_analysis/network_data/__init__.py
@@ -420,11 +420,13 @@ class CreateNetworkDataModule(CreateValueModule):
 
         input_file: KiaraFile = value.get_value_data()
 
-        try:
-            graph = nx.read_gml(input_file.path)
-        except Exception as e:
-            print(f"That didn't work: {e}")
-            graph = nx.read_gml(input_file.path, label="id")
+        # keep the minimalist version only with label as id
+        # if laybels are present they are still preserved as node attributes
+        # try:
+        #     graph = nx.read_gml(input_file.path)
+        # except Exception as e:
+        #     print(f"That didn't work: {e}")
+        graph = nx.read_gml(input_file.path, label="id")
 
         network_data = NetworkData.create_from_networkx_graph(graph)
         return network_data


### PR DESCRIPTION
To avoid incomplete or missing data in the label field of a gml file, the default is set to take the id field as label.